### PR TITLE
Add Densha de Go! 64 English v1.03 hash

### DIFF
--- a/N64-database.txt
+++ b/N64-database.txt
@@ -78,6 +78,7 @@ fe3119cc47334e64faedf1435517078d ntsc|cic6102 # Caribbean Nights by Megahawks In
 24066da301c3e6f86966debfb892551f ntsc|cic6102 # Coco Demo (PD)
 c7a8ec9386ab97f621dcb530e92b16b0 ntsc|cic6102|cpak|rpak|tpak # ControllerTest
 527a117bebff661f3546522200e63dab ntsc|cic5167|eeprom2k|rpak|tpak # Densha de Go! 64 (English v 1.01)
+91131a1bb91aa42d3e8f2aa55948041f ntsc|cic5167|eeprom2k|rpak|tpak # Densha de Go! 64 (English v 1.03)
 76f40c0b400800f2084d48cb0eb80272 ntsc|cic6102|flash128k|cpak # Derby Stallion 64 (Beta)
 e3cc7b27dbd77b44370550543be0b19a ntsc|cic6102 # Dexanoid R1 by Protest Design
 e09272dcb2a26b97d20f198dd8729abc ntsc|cic6102 # Dexanoid R1 by Protest Design


### PR DESCRIPTION
Fixes #29.

Adds the missing Densha de Go! 64 English v1.03 patched ROM MD5 entry to `N64-database.txt`.

Added entry:

`91131a1bb91aa42d3e8f2aa55948041f ntsc|cic5167|eeprom2k|rpak|tpak # Densha de Go! 64 (English v 1.03)`

The existing v1.01 entry is preserved unchanged.

Verification performed:

* confirmed the v1.03 MD5 was not already present
* confirmed the new MD5 appears exactly once
* verified the MD5 against RetroAchievements RAHashes, which maps it to `Densha de Go! 64 (Japan) [T-En by Zoinkity v1.03].z64`
* kept the same MiSTer attributes as the existing accepted v1.01 English patch entry: `ntsc|cic5167|eeprom2k|rpak|tpak`
* confirmed Densha base fallback uses `eeprom2k|rpak`
* `git diff --check`
* `git diff --cached --check`
* `git show --check HEAD`

Only `N64-database.txt` is changed.